### PR TITLE
Fix checking empty region’s major and minor.

### DIFF
--- a/android/src/main/java/com/mackentoch/beaconsandroid/BeaconsAndroidModule.java
+++ b/android/src/main/java/com/mackentoch/beaconsandroid/BeaconsAndroidModule.java
@@ -172,8 +172,8 @@ public class BeaconsAndroidModule extends ReactContextBaseJavaModule implements 
             Region region = createRegion(
               regionId,
               beaconUuid,
-              String.valueOf(minor) != "-1" ? String.valueOf(minor) : "",
-              String.valueOf(major) != "-1" ? String.valueOf(major) : ""
+              String.valueOf(minor).equals("-1") ? "" : String.valueOf(minor),
+              String.valueOf(major).equals("-1") ? "" : String.valueOf(major)
             );
             mBeaconManager.startMonitoringBeaconsInRegion(region);
             resolve.invoke();
@@ -214,8 +214,8 @@ public class BeaconsAndroidModule extends ReactContextBaseJavaModule implements 
         Region region = createRegion(
           regionId,
           beaconUuid,
-          String.valueOf(minor) != "-1" ? String.valueOf(minor) : "",
-          String.valueOf(major) != "-1" ? String.valueOf(major) : ""
+          String.valueOf(minor).equals("-1") ? "" : String.valueOf(minor),
+          String.valueOf(major).equals("-1") ? "" : String.valueOf(major)
           // minor,
           // major
         );


### PR DESCRIPTION
Issue: [#1 startMonitoringForRegion without major and minor](https://github.com/MacKentoch/react-native-beacons-manager/issues/1)

Fixed by using `String.equals` for checking string equality. As string returned by `String.valueOf` is not interned, so using `==` or `!=` gives wrong result. 