### PR TITLE
Update RNiBeacon.m

### DIFF
--- a/ios/RNiBeacon/RNiBeacon/RNiBeacon.m
+++ b/ios/RNiBeacon/RNiBeacon/RNiBeacon.m
@@ -258,7 +258,7 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
 -(void)locationManager:(CLLocationManager *)manager
         didEnterRegion:(CLBeaconRegion *)region {
   NSDictionary *event = @{
-                          @"region": region.identifier,
+                          @"identifier": region.identifier,
                           @"uuid": [region.proximityUUID UUIDString],
                           };
 
@@ -268,7 +268,7 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
 -(void)locationManager:(CLLocationManager *)manager
          didExitRegion:(CLBeaconRegion *)region {
   NSDictionary *event = @{
-                          @"region": region.identifier,
+                          @"identifier": region.identifier,
                           @"uuid": [region.proximityUUID UUIDString],
                           };
 


### PR DESCRIPTION
For #18 - This maybe the issue I was having. There is an inconsistency in the Android and iOS messaging to RN. So in Android we are emitting `identifier`, and in iOS, we are emitting `region`. Recommend to make them both consistent.