### PR TITLE
Make search header work with expokit

### DIFF
--- a/ios/RNiBeacon/RNiBeacon.xcodeproj/project.pbxproj
+++ b/ios/RNiBeacon/RNiBeacon.xcodeproj/project.pbxproj
@@ -226,7 +226,11 @@
 			buildSettings = {
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = "";
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../node_modules/react-native/React";
+				HEADER_SEARCH_PATHS = (
+					"<Multiple",
+					"values>",
+					"${SRCROOT}/../../../../ios/Pods/Headers/Public",
+				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -238,7 +242,11 @@
 			buildSettings = {
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = "";
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../../react-native/React";
+				HEADER_SEARCH_PATHS = (
+					"<Multiple",
+					"values>",
+					"${SRCROOT}/../../../../ios/Pods/Headers/Public",
+				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
I'm using Expo and when I make use of the Eject function and got to expokit this library wasn't bad connected cause of the search header. I think this is cause of expo use cocoapods. Now with that work like a charm.