### PR TITLE
Fixed android constants export that prevented successful compilation on iOS

### DIFF
--- a/android/src/main/java/com/mackentoch/beaconsandroid/BeaconsAndroidModule.java
+++ b/android/src/main/java/com/mackentoch/beaconsandroid/BeaconsAndroidModule.java
@@ -66,8 +66,6 @@ public class BeaconsAndroidModule extends ReactContextBaseJavaModule implements 
         constants.put("NOT_SUPPORTED_BLE", BeaconTransmitter.NOT_SUPPORTED_BLE);
         constants.put("NOT_SUPPORTED_CANNOT_GET_ADVERTISER_MULTIPLE_ADVERTISEMENTS", BeaconTransmitter.NOT_SUPPORTED_CANNOT_GET_ADVERTISER_MULTIPLE_ADVERTISEMENTS);
         constants.put("NOT_SUPPORTED_CANNOT_GET_ADVERTISER", BeaconTransmitter.NOT_SUPPORTED_CANNOT_GET_ADVERTISER);
-        constants.put("RUNNING_AVG_RSSI_FILTER",RUNNING_AVG_RSSI_FILTER);
-        constants.put("ARMA_RSSI_FILTER",ARMA_RSSI_FILTER);
         return constants;
     }
 

--- a/lib/module.android.js
+++ b/lib/module.android.js
@@ -22,8 +22,8 @@ const tramissionSupport: Array<string> = [
   'NOT_SUPPORTED_CANNOT_GET_ADVERTISER_MULTIPLE_ADVERTISEMENTS'
 ];
 
-const ARMA_RSSI_FILTER = beaconsAndroid.ARMA_RSSI_FILTER;
-const RUNNING_AVG_RSSI_FILTER = beaconsAndroid.RUNNING_AVG_RSSI_FILTER;
+const RUNNING_AVG_RSSI_FILTER = 0;
+const ARMA_RSSI_FILTER = 1;
 
 function setHardwareEqualityEnforced(e: boolean): void {
   beaconsAndroid.setHardwareEqualityEnforced(e);


### PR DESCRIPTION
Constants were introduced with `setRssiFilter` function.