### PR TITLE
Added requiresMainQueueSetup to iOS module

### DIFF
--- a/ios/RNiBeacon/RNiBeacon/RNiBeacon.m
+++ b/ios/RNiBeacon/RNiBeacon/RNiBeacon.m
@@ -248,8 +248,8 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
                           @"state":   [self stringForState:state],
                           @"identifier":  region.identifier,
                           };
-  
-    [self sendEventWithName:@"didDetermineState" body:event];  
+
+    [self sendEventWithName:@"didDetermineState" body:event];
 }
 
 -(void) locationManager:(CLLocationManager *)manager didRangeBeacons:
@@ -303,5 +303,9 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
     [self sendEventWithName:@"regionDidExit" body:event];
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
 
 @end


### PR DESCRIPTION
Received a warning about this when building the latest code. I found that by implementing this change I had much more consistent behaviour with entry & exit events