### PR TITLE
iOS support for getMonitoredRegions() and major/minor in events

### DIFF
--- a/lib/next/module.types.js
+++ b/lib/next/module.types.js
@@ -51,6 +51,7 @@ export type BeaconsManagerIOS = {
   requestWhenInUseAuthorization: () => void,
   allowsBackgroundLocationUpdates: (allow: boolean) => void,
   getAuthorizationStatus: (cb: GetAuthorizationCallback) => void,
+  getMonitoredRegions: (value?: any) => void,
   startUpdatingLocation: () => void,
   stopUpdatingLocation: () => void,
   shouldDropEmptyRanges: (drop: boolean) => void,

--- a/lib/next/new.module.ios.js
+++ b/lib/next/new.module.ios.js
@@ -48,6 +48,17 @@ function getAuthorizationStatus(
 }
 
 /**
+ * get monitored regions
+ *
+ * @returns {Promise<Array<BeaconRegion>>} promise resolve to an array of monitored regions
+ */
+function getMonitoredRegions(): Promise<Array<BeaconRegion>> {
+  return new Promise((resolve, reject) => {
+    BeaconsManager.getMonitoredRegions(resolve);
+  });
+}
+
+/**
  * call is needed for monitoring beacons and gets the initial position of the device.
  *
  */
@@ -159,6 +170,7 @@ module.exports =  {
   requestWhenInUseAuthorization,
   allowsBackgroundLocationUpdates,
   getAuthorizationStatus,
+  getMonitoredRegions,
   startUpdatingLocation,
   stopUpdatingLocation,
   shouldDropEmptyRanges,


### PR DESCRIPTION
This PR brings the ios module closer to parity with android.
- Added getMonitoredRegions() to ios module
- Added major and minor to regionDidEnter and regionDidExit events for ios