### PR TITLE
pull in latest altbeacon binary which contains fix for android 8+ background scan issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,5 +29,5 @@ repositories {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.facebook.react:react-native:0.12.+'
-    compile 'org.altbeacon:android-beacon-library:2.9.2'
+    compile 'org.altbeacon:android-beacon-library:2.13.1'
 }


### PR DESCRIPTION
https://github.com/AltBeacon/android-beacon-library/pull/637

