### PR TITLE
Added React as a Pod dependency (Fix #92)

### DIFF
--- a/ReactNativeBeaconsManager.podspec
+++ b/ReactNativeBeaconsManager.podspec
@@ -8,4 +8,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "8.0"
   s.source       = { :path => "." }
   s.source_files = "ios", "ios/**/*.{h,m}"
+
+  s.dependency 'React'
 end


### PR DESCRIPTION
Hi,

This PR is just adding React as a Pod dependency for projects with a Pod setup (Fix Issue #92 ).

I suppose that Pod does not provide all headers to all deps.

This also made this library work with ExpoKit.