### PR TITLE
don't fail when native modules missing

### DIFF
--- a/lib/next/new.module.android.js
+++ b/lib/next/new.module.android.js
@@ -24,8 +24,8 @@ const BeaconsManager: BeaconsManagerANDROID =
   RN.NativeModules.BeaconsAndroidModule;
 const BeaconsEventEmitter = RN.DeviceEventEmitter;
 
-const ARMA_RSSI_FILTER = BeaconsManager.ARMA_RSSI_FILTER;
-const RUNNING_AVG_RSSI_FILTER = BeaconsManager.RUNNING_AVG_RSSI_FILTER;
+const ARMA_RSSI_FILTER = BeaconsManager && BeaconsManager.ARMA_RSSI_FILTER || undefined;
+const RUNNING_AVG_RSSI_FILTER = BeaconsManager && BeaconsManager.RUNNING_AVG_RSSI_FILTER || undefined;
 // #endregion
 
 function setHardwareEqualityEnforced(flag: boolean): void {

--- a/lib/next/new.module.ios.js
+++ b/lib/next/new.module.ios.js
@@ -9,7 +9,7 @@ import {
 } from './module.types';
 
 const BeaconsManager: BeaconsManagerIOS = RN.NativeModules.RNiBeacon;
-const BeaconsEventEmitter = new RN.NativeEventEmitter(BeaconsManager);
+const BeaconsEventEmitter = BeaconsManager && new RN.NativeEventEmitter(BeaconsManager) || undefined;
 
 /**
  * request always authorization (mandatory when ranging beacons but energy drain)


### PR DESCRIPTION
We're working on an SDK that optionally provides beacon functionality. However some SDK consumer apps don't rely on this functionality and thus they don't want the native code to be compiled and added to their application (to avoid store review issues with permissions...etc). So we needed a way to let the JS code in stay the SDK silently but exclude the native code, but these changes were needed to avoid crashing on module load.