### PR TITLE
Adding the missing lib

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -104,5 +104,6 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.facebook.react:react-native:0.61.+'
+    implementation 'com.intellij:annotations:+@jar'
     compile 'org.altbeacon:android-beacon-library:2.16.1'
 }


### PR DESCRIPTION
Adding a missing package
: package org.jetbrains.annotations does not exist
import org.jetbrains.annotations.Nullable;