### PR TITLE
Fixed breaking AltBeacon Version - Updated to 2.19 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -105,5 +105,5 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.facebook.react:react-native:0.6+'
     implementation 'com.intellij:annotations:+@jar'
-    compile 'org.altbeacon:android-beacon-library:2.16.1'
+    compile 'org.altbeacon:android-beacon-library:2.19'
 }


### PR DESCRIPTION
AltBeacon has removed its 2.16 versions from mavencentral and it was breaking the android dependencies.
https://mvnrepository.com/artifact/org.altbeacon/android-beacon-library