### PR TITLE
fix android build, update beacon library

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -105,5 +105,5 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.facebook.react:react-native:0.6+'
     implementation 'com.intellij:annotations:+@jar'
-    compile 'org.altbeacon:android-beacon-library:2.16.1'
+    implementation 'org.altbeacon:android-beacon-library:2.19.4'
 }


### PR DESCRIPTION
Pointing to the last commit #fed160c on master, the library did not compile with mi react-native project. I have to make this change to be able to compile.

Thanks